### PR TITLE
fix: 15 GitHub actions to publish docker image

### DIFF
--- a/.github/workflows/publish_hortacloud_deployment.yml
+++ b/.github/workflows/publish_hortacloud_deployment.yml
@@ -13,7 +13,7 @@ jobs:
     name: Bump version
     runs-on: ubuntu-latest
     outputs:
-      new_version: ${{ steps.output_version.outputs.new_version }}
+      new_version: ${{ steps.update_dockerfile.outputs.new_version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -22,6 +22,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.SERVICE_TOKEN }}
     - name: Check changes and bump version in file
+      id: update_dockerfile
       run: |
         docker_file=${{ env.DOCKERFILE_PATH }}
         first_line=$(head -n 1 $docker_file)

--- a/.github/workflows/publish_hortacloud_deployment.yml
+++ b/.github/workflows/publish_hortacloud_deployment.yml
@@ -1,12 +1,15 @@
-name: Tag and publish
+name: Publish hortacloud_deployment
 on:
   push:
     branches:
       - main
     paths:
       - hortacloud-deployment/**
+env:
+    DOCKERFILE_DIR: ./hortacloud-deployment
+    DOCKERFILE_PATH: ./hortacloud-deployment/Dockerfile
 jobs:
-  bump-version:
+  bump_version:
     name: Bump version
     runs-on: ubuntu-latest
     outputs:
@@ -18,30 +21,41 @@ jobs:
         ref: ${{ inputs.default_branch }}
         fetch-depth: 0
         token: ${{ secrets.SERVICE_TOKEN }}
-    - name: Get version file name set variables
+    - name: Check changes and bump version in file
       run: |
-        docker_file="./hortacloud-deployment/Dockerfile"
+        docker_file=${{ env.DOCKERFILE_PATH }}
         first_line=$(head -n 1 $docker_file)
         old_version=${first_line:3}
         most_recent_commit=$(git log --oneline | head -1)
-        echo "VERSION_FILE=$docker_file" >> "$GITHUB_ENV"
-        echo "VERSION=${{ steps.tag_version.outputs.new_version }}" >> "$GITHUB_ENV"
-    - name: Update version file with new version
-      run: |
-        grep "__version__" "$VERSION_FILE"
-        sed -i --debug --expression="s|__version__.*|__version__ = \"${{ env.VERSION }}\"|" "$VERSION_FILE"
-    - name: Set output
-      id: output_version
-      run: echo "new_version=${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
+        echo "Most recent commit message first line:"
+        echo " ${most_recent_commit}"
+        if [[ "${most_recent_commit^^}" == *"BREAKING CHANGE"* ]]; then
+          echo "Major version bump"
+          new_version=$(IFS=. read -r a b c<<<"$old_version";echo "$((a+1)).0.0")
+        elif [[ "${most_recent_commit^^}" == *"FEAT"* ]]; then
+          echo "Minor version bump"
+          new_version=$(IFS=. read -r a b c<<<"$old_version";echo "$a.$((b+1)).0")
+        else
+          echo "Patch version bump"
+          new_version=$(IFS=. read -r a b c<<<"$old_version";echo "$a.$b.$((c+1))")
+        fi
+        echo "Saving new_version to GITHUB_OUTPUT"
+        echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+        echo "Updating version number in ${docker_file}"
+        new_docker_file_line="# v${new_version}"
+        sed -i "1s/.*/$new_docker_file_line/" ${docker_file}
+      else
+        echo "No changes in hortacloud-deployment"
+      fi
     - name: Commit and Push version bump
       uses: EndBug/add-and-commit@v9
       with:
         default_author: github_actions
         message: "ci: version bump [skip actions]"
-        add: ${{ env.VERSION_FILE }}
+        add: ${{ env.DOCKERFILE_PATH }}
   publish:
     runs-on: ubuntu-latest
-    needs: update_version
+    needs: bump_version
     steps:
       - uses: actions/checkout@v3
       - name: Pull latest changes
@@ -59,8 +73,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           # relative path to the place where source code with Dockerfile is located
-          context: ./horta-deployment
+          context: ${{ env.DOCKERFILE_DIR }}
           push: true
           tags: |
-            ghcr.io/allenneuraldynamics/hortacloud-deployment:${{ needs.tag.outputs.new_version }}
+            ghcr.io/allenneuraldynamics/hortacloud-deployment:${{ needs.bump_version.outputs.new_version }}
             ghcr.io/allenneuraldynamics/hortacloud-deployment:latest

--- a/.github/workflows/publish_hortacloud_deployment.yml
+++ b/.github/workflows/publish_hortacloud_deployment.yml
@@ -44,9 +44,6 @@ jobs:
         echo "Updating version number in ${docker_file}"
         new_docker_file_line="# v${new_version}"
         sed -i "1s/.*/$new_docker_file_line/" ${docker_file}
-      else
-        echo "No changes in hortacloud-deployment"
-      fi
     - name: Commit and Push version bump
       uses: EndBug/add-and-commit@v9
       with:

--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -6,14 +6,42 @@ on:
     paths:
       - hortacloud-deployment/**
 jobs:
-  tag:
-    uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
-    secrets:
-      SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }}
-
+  bump-version:
+    name: Bump version
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.output_version.outputs.new_version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.default_branch }}
+        fetch-depth: 0
+        token: ${{ secrets.SERVICE_TOKEN }}
+    - name: Get version file name set variables
+      run: |
+        docker_file="./hortacloud-deployment/Dockerfile"
+        first_line=$(head -n 1 $docker_file)
+        old_version=${first_line:3}
+        most_recent_commit=$(git log --oneline | head -1)
+        echo "VERSION_FILE=$docker_file" >> "$GITHUB_ENV"
+        echo "VERSION=${{ steps.tag_version.outputs.new_version }}" >> "$GITHUB_ENV"
+    - name: Update version file with new version
+      run: |
+        grep "__version__" "$VERSION_FILE"
+        sed -i --debug --expression="s|__version__.*|__version__ = \"${{ env.VERSION }}\"|" "$VERSION_FILE"
+    - name: Set output
+      id: output_version
+      run: echo "new_version=${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
+    - name: Commit and Push version bump
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: "ci: version bump [skip actions]"
+        add: ${{ env.VERSION_FILE }}
   publish:
     runs-on: ubuntu-latest
-    needs: tag
+    needs: update_version
     steps:
       - uses: actions/checkout@v3
       - name: Pull latest changes

--- a/hortacloud-deployment/Dockerfile
+++ b/hortacloud-deployment/Dockerfile
@@ -1,3 +1,4 @@
+# v0.0.0
 from node:16
 
 RUN apt-get update && \


### PR DESCRIPTION
Closes #15 

- Fixes workflow to publish hortacloud deployment docker image to registry
- Adds script to parse commit message and bump version accordingly
- Adds version number as comment in Dockerfile
- Tested variables are set accordingly in test repo