### PR TITLE
ci: bump workflow actions to Node 24 versions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/publish_aind_airflow.yml
+++ b/.github/workflows/publish_aind_airflow.yml
@@ -16,7 +16,7 @@ jobs:
       new_version: ${{ steps.update_dockerfile.outputs.new_version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.default_branch }}
         fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
         new_docker_file_line="# v${new_version}"
         sed -i "1s/.*/$new_docker_file_line/" ${docker_file}
     - name: Commit and Push version bump
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@v10
       with:
         default_author: github_actions
         message: "ci: version bump [skip actions]"
@@ -55,20 +55,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: bump_version
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Pull latest changes
         run: git pull origin main
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ${{ env.DOCKERFILE_DIR }}

--- a/.github/workflows/publish_cuda11_miniconda_jupyterlab.yml
+++ b/.github/workflows/publish_cuda11_miniconda_jupyterlab.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -21,15 +21,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish_cuda12_miniconda_jupyterlab.yml
+++ b/.github/workflows/publish_cuda12_miniconda_jupyterlab.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -21,15 +21,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish_cuda12_runtime_uv.yml
+++ b/.github/workflows/publish_cuda12_runtime_uv.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -21,15 +21,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./${{ env.IMAGE_NAME }}
           push: true

--- a/.github/workflows/publish_hortacloud_deployment.yml
+++ b/.github/workflows/publish_hortacloud_deployment.yml
@@ -16,7 +16,7 @@ jobs:
       new_version: ${{ steps.update_dockerfile.outputs.new_version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.default_branch }}
         fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
         new_docker_file_line="# v${new_version}"
         sed -i "1s/.*/$new_docker_file_line/" ${docker_file}
     - name: Commit and Push version bump
-      uses: EndBug/add-and-commit@v9
+      uses: EndBug/add-and-commit@v10
       with:
         default_author: github_actions
         message: "ci: version bump [skip actions]"
@@ -55,20 +55,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: bump_version
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Pull latest changes
         run: git pull origin main
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ${{ env.DOCKERFILE_DIR }}

--- a/.github/workflows/publish_lightning_jupyterlab.yml
+++ b/.github/workflows/publish_lightning_jupyterlab.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -21,15 +21,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish_lightning_jupyterlab_py39.yml
+++ b/.github/workflows/publish_lightning_jupyterlab_py39.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -21,15 +21,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish_pytorch_py310.yml
+++ b/.github/workflows/publish_pytorch_py310.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -22,15 +22,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish_pytorch_tensorflow_jax.yml
+++ b/.github/workflows/publish_pytorch_tensorflow_jax.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -21,15 +21,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish_r2u_rstudio.yml
+++ b/.github/workflows/publish_r2u_rstudio.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -22,15 +22,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish_ubuntu_ffmpeg.yml
+++ b/.github/workflows/publish_ubuntu_ffmpeg.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute new docker image tag
         run: |
           echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
@@ -21,15 +21,15 @@ jobs:
           echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./${{ env.IMAGE_NAME }}
           push: true


### PR DESCRIPTION
## Summary

- Bump every referenced GitHub Action to its latest Node 24-compatible major version, clearing the Node 20 deprecation warning that was firing on every publish run (GitHub is flipping the default to Node 24 on 2026-06-02 and removing Node 20 entirely on 2026-09-16).
- Add `.github/dependabot.yml` with a weekly grouped `github-actions` update so the next round of deprecations opens one consolidated PR instead of us chasing warnings manually.

### Version bumps

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v3 / v4 | **v6** |
| `docker/setup-buildx-action` | v2 | **v4** |
| `docker/login-action` | v2 | **v4** |
| `docker/build-push-action` | v3 | **v7** |
| `EndBug/add-and-commit` | v9 | **v10** |
| `actions/add-to-project` | v1.0.2 | (already latest, unchanged) |

All 11 publish workflows were touched; `add_issue_to_project_board.yml` was already on the latest `add-to-project` release.

## Test plan

- [ ] Merge; wait for the next push to any `paths:`-watched subdir (or manually trigger one of the `workflow_dispatch` workflows, e.g. `publish_cuda12_runtime_uv`) and confirm the deprecation warning is gone
- [ ] Confirm Dependabot opens a single grouped PR the next time any of these actions cuts a release