### PR TITLE
feat: add cuda12-base-uv base image

### DIFF
--- a/.github/workflows/publish_cuda12_base_uv.yml
+++ b/.github/workflows/publish_cuda12_base_uv.yml
@@ -1,0 +1,38 @@
+name: Publish cuda12-base-uv
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - cuda12-base-uv/**
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: cuda12-base-uv
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compute new docker image tag
+        run: |
+          echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+          echo "branch=$(echo ${GITHUB_REF_NAME})" >> "$GITHUB_ENV"
+          echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to Github Packages
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image and push to GitHub Container Registry
+        uses: docker/build-push-action@v7
+        with:
+          context: ./${{ env.IMAGE_NAME }}
+          push: true
+          tags: |
+            ghcr.io/allenneuraldynamics/${{ env.IMAGE_NAME }}:${{ env.docker_tag }}
+            ghcr.io/allenneuraldynamics/${{ env.IMAGE_NAME }}:latest

--- a/cuda12-base-uv/Dockerfile
+++ b/cuda12-base-uv/Dockerfile
@@ -1,0 +1,59 @@
+# Minimal base: NVIDIA CUDA 12 `base` variant + uv-managed Python 3.13.
+# No conda, no ML framework, no notebook server baked in — add what
+# you need in your capsule.
+#
+# Variant: `base` — ships only the CUDA driver stub (libcuda.so) and
+# env vars; no libcudart/libcublas/libcufft/libcurand/libcusparse/NCCL/
+# cuDNN. ~2.3 GB smaller than the `runtime` variant.
+#
+# Use this when the downstream capsule installs pytorch (or tensorflow,
+# jax, cupy) via pip/uv — those wheels bundle their own CUDA runtime
+# libraries and don't link against the system copies. If you need
+# system cuBLAS/cuDNN/NCCL (rare in modern Python ML stacks), use
+# cuda12-runtime-uv instead.
+#
+# GPU availability is a deployment-time concern: the host driver is
+# bind-mounted by nvidia-container-toolkit only when the container is
+# run with --gpus (on Code Ocean, controlled by the capsule's machine
+# type).
+
+# Stage 1: uv binary, pulled from Astral's distroless image.
+FROM ghcr.io/astral-sh/uv:0.11.7 AS uv
+
+# Stage 2: `base` on CUDA 12.8 / Ubuntu 24.04
+FROM docker.io/nvidia/cuda:12.8.1-base-ubuntu24.04
+
+LABEL org.opencontainers.image.source="https://github.com/AllenNeuralDynamics/aind-docker-images"
+LABEL org.opencontainers.image.description="CUDA 12.8 base (driver stub only) + uv-managed Python 3.13. Minimal GPU base for AIND capsules that install pytorch/jax/cupy via pip."
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Matplotlib default: headless-safe for reproducible runs.
+ENV MPLBACKEND=Agg
+ENV VIRTUAL_ENV=/opt/venv
+# /opt/venv/bin wins over anything the base image puts on PATH.
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+
+# Minimal apt packages. No build-essential — cp313 wheels cover the
+# common scientific stack (numpy, scipy, pandas, torch, numba). If a
+# downstream capsule needs to compile a C extension, it can apt-install
+# build-essential in its own postInstall.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bzip2 ca-certificates curl git locales unzip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# uv binary from the Astral distroless image.
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+# Install a managed Python 3.13 and create a dedicated venv at /opt/venv.
+RUN uv python install 3.13 \
+ && uv venv --python 3.13 ${VIRTUAL_ENV} \
+ && rm -rf /root/.cache/uv \
+ # Shadow any system python/pip so scripts that say `python3` or `pip`
+ # resolve to the venv regardless of how they're invoked.
+ && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python \
+ && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python3 \
+ && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip \
+ && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip3


### PR DESCRIPTION
Minimal GPU-capable base: NVIDIA CUDA 12.8 `base` variant (driver stub only, no libcudart/libcublas/libcufft/libcurand/libcusparse/NCCL/cuDNN)
+ uv-managed Python 3.13. ~2.3 GB smaller than cuda12-runtime-uv.

Use this when the downstream capsule installs pytorch/tensorflow/jax/ cupy via pip — those wheels bundle their own CUDA runtime libraries and don't link against the system copies. For packages that need system cuBLAS/cuDNN/NCCL (rare in modern Python ML stacks), use cuda12-runtime-uv instead.