### PR TITLE
feat: add python-slim-uv base image

### DIFF
--- a/.github/workflows/publish_python_slim_uv.yml
+++ b/.github/workflows/publish_python_slim_uv.yml
@@ -1,0 +1,38 @@
+name: Publish python-slim-uv
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - python-slim-uv/**
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: python-slim-uv
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compute new docker image tag
+        run: |
+          echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+          echo "branch=$(echo ${GITHUB_REF_NAME})" >> "$GITHUB_ENV"
+          echo "docker_tag=$(echo ${GITHUB_REF_NAME})-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to Github Packages
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image and push to GitHub Container Registry
+        uses: docker/build-push-action@v7
+        with:
+          context: ./${{ env.IMAGE_NAME }}
+          push: true
+          tags: |
+            ghcr.io/allenneuraldynamics/${{ env.IMAGE_NAME }}:${{ env.docker_tag }}
+            ghcr.io/allenneuraldynamics/${{ env.IMAGE_NAME }}:latest

--- a/python-slim-uv/Dockerfile
+++ b/python-slim-uv/Dockerfile
@@ -1,0 +1,57 @@
+# Minimal CPU-only base: python:3.13-slim-bookworm + uv.
+# No conda, no ML framework, no notebook server baked in — add what
+# you need in your capsule.
+#
+# Debian slim rather than Ubuntu because:
+# - ~150 MB smaller than ubuntu:24.04 + uv-install-python, which pays
+#   back on every Code Ocean pipeline cold start.
+# - Python 3.13 is already installed by the upstream official image;
+#   no build-time download via `uv python install`.
+# - apt package names and system dependencies are effectively identical
+#   to Ubuntu for the packages a capsule actually installs (build-essential,
+#   libgl1, libglib2.0-0, ffmpeg, etc.). PPAs are the main thing that
+#   won't work, but pipeline capsules don't use PPAs.
+#
+# For GPU-capable roles use cuda12-runtime-uv or cuda12-base-uv.
+
+# Stage 1: uv binary, pulled from Astral's distroless image.
+FROM ghcr.io/astral-sh/uv:0.11.7 AS uv
+
+# Stage 2: Docker Official Python image, Debian bookworm slim.
+FROM docker.io/python:3.13-slim-bookworm
+
+LABEL org.opencontainers.image.source="https://github.com/AllenNeuralDynamics/aind-docker-images"
+LABEL org.opencontainers.image.description="python:3.13-slim-bookworm + uv. Minimal CPU-only base for AIND capsules."
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Matplotlib default: headless-safe for reproducible runs.
+ENV MPLBACKEND=Agg
+ENV VIRTUAL_ENV=/opt/venv
+# /opt/venv/bin wins over anything the base image puts on PATH.
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+
+# Minimal apt packages. No build-essential — cp313 wheels cover the
+# common scientific stack (numpy, scipy, pandas, numba). If a
+# downstream capsule needs to compile a C extension, it can apt-install
+# build-essential in its own postInstall.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bzip2 ca-certificates curl git locales unzip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# uv binary from the Astral distroless image.
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+# Create a dedicated venv at /opt/venv using the base image's Python 3.13
+# (no `uv python install` — the official python:3.13-slim-bookworm image
+# already provides the exact interpreter we want).
+RUN uv venv --python python3.13 ${VIRTUAL_ENV} \
+ && rm -rf /root/.cache/uv \
+ # Shadow system python/pip so scripts that say `python3` or `pip`
+ # resolve to the venv regardless of how they're invoked.
+ && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python \
+ && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python3 \
+ && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip \
+ && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip3


### PR DESCRIPTION
Minimal CPU-only base: python:3.13-slim-bookworm + uv. For pipeline roles (launcher, aggregator, CPU-only workers) where the code-server CPU base's ~1-2 GB of interactive tooling is pure cold-start latency.

Debian slim chosen over ubuntu:24.04 + uv-install-python because:
- ~150 MB smaller; pays back on every CO pipeline cold start
- Python 3.13 already provided by the upstream official image
- apt package names identical to Ubuntu for the deps capsules use
- PPAs are the main surprise, but pipeline capsules don't use PPAs