### PR TITLE
Add pip into uv-managed venvs

### DIFF
--- a/cuda12-base-uv/Dockerfile
+++ b/cuda12-base-uv/Dockerfile
@@ -48,8 +48,10 @@ RUN apt-get update \
 COPY --from=uv /uv /uvx /usr/local/bin/
 
 # Install a managed Python 3.13 and create a dedicated venv at /opt/venv.
+# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists for the
+# symlinks below (and so Code Ocean's GUI recognises pip as available).
 RUN uv python install 3.13 \
- && uv venv --python 3.13 ${VIRTUAL_ENV} \
+ && uv venv --seed --python 3.13 ${VIRTUAL_ENV} \
  && rm -rf /root/.cache/uv \
  # Shadow any system python/pip so scripts that say `python3` or `pip`
  # resolve to the venv regardless of how they're invoked.

--- a/cuda12-runtime-uv/Dockerfile
+++ b/cuda12-runtime-uv/Dockerfile
@@ -44,8 +44,10 @@ RUN apt-get update \
 COPY --from=uv /uv /uvx /usr/local/bin/
 
 # Install a managed Python 3.13 and create a dedicated venv at /opt/venv.
+# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists for the
+# symlinks below (and so Code Ocean's GUI recognises pip as available).
 RUN uv python install 3.13 \
- && uv venv --python 3.13 ${VIRTUAL_ENV} \
+ && uv venv --seed --python 3.13 ${VIRTUAL_ENV} \
  && rm -rf /root/.cache/uv \
  # Shadow any system python/pip so scripts that say `python3` or `pip`
  # resolve to the venv regardless of how they're invoked.

--- a/python-slim-uv/Dockerfile
+++ b/python-slim-uv/Dockerfile
@@ -47,7 +47,9 @@ COPY --from=uv /uv /uvx /usr/local/bin/
 # Create a dedicated venv at /opt/venv using the base image's Python 3.13
 # (no `uv python install` — the official python:3.13-slim-bookworm image
 # already provides the exact interpreter we want).
-RUN uv venv --python python3.13 ${VIRTUAL_ENV} \
+# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists for the
+# symlinks below (and so Code Ocean's GUI recognises pip as available).
+RUN uv venv --seed --python python3.13 ${VIRTUAL_ENV} \
  && rm -rf /root/.cache/uv \
  # Shadow system python/pip so scripts that say `python3` or `pip`
  # resolve to the venv regardless of how they're invoked.


### PR DESCRIPTION
`uv venv` alone does not install pip, so the subsequent `ln -sf /opt/venv/bin/pip /usr/local/bin/pip{,3}` lines were creating dangling symlinks. Code Ocean's GUI treats pip/pip3 as unavailable when the binaries don't resolve, disabling pip as a package-manager option.

Adding `--seed` tells uv to install pip into the new venv (`pip 26.0.1` on Python 3.13), so the existing symlinks resolve and Code Ocean recognises pip.

Applies to cuda12-base-uv, cuda12-runtime-uv, and python-slim-uv.