### PR TITLE
chore: add Dependabot config for Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,33 @@ updates:
       actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/aind-airflow"
+      - "/cuda11-miniconda-jupyterlab"
+      - "/cuda12-base-uv"
+      - "/cuda12-miniconda-jupyterlab"
+      - "/cuda12-runtime-uv"
+      - "/hortacloud-deployment"
+      - "/lightning-jupyterlab"
+      - "/lightning-jupyterlab-py39"
+      - "/python-slim-uv"
+      - "/pytorch-py310"
+      - "/pytorch-tensorflow-jax"
+      - "/r2u-rstudio"
+      - "/ubuntu-ffmpeg"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"
+    ignore:
+      # Stay on CUDA 12 until PyTorch ships wheels for CUDA 13. Stable
+      # torch 2.7.0 only builds against 11.8 / 12.6 / 12.8, and the
+      # cuda12-*-uv image names encode the major version — a CUDA 13
+      # move needs a rename, not a pin bump. Patch bumps (12.x.y) still
+      # open PRs.
+      - dependency-name: "nvidia/cuda"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Extend `.github/dependabot.yml` with a `docker` ecosystem entry covering every image directory in the repo. Weekly schedule, PRs grouped into one per week (matches the existing `github-actions` entry).

Each `FROM` / `COPY --from=...` line in the Dockerfiles becomes a tracked dependency — so upstream bumps (ubuntu, nvidia/cuda, python, miniforge3, static-ffmpeg, astral-sh/uv, apache/airflow, node) surface as PRs instead of needing manual spelunking. The sibling PR #41 is exactly the kind of work Dependabot would now do on its own.

## CUDA 13 ignore rule

`nvidia/cuda` major bumps (12 → 13) are ignored. PyTorch 2.7.0 stable still only ships wheels for CUDA 11.8 / 12.6 / 12.8, and the `cuda12-*-uv` image names encode the major version — a CUDA 13 move requires a rename, not a pin bump. Patch bumps within 12.x still generate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)