### PR TITLE
fix: wrapper for /usr/local/bin/python to activate the venv

### DIFF
--- a/cuda12-base-uv/Dockerfile
+++ b/cuda12-base-uv/Dockerfile
@@ -48,14 +48,21 @@ RUN apt-get update \
 COPY --from=uv /uv /uvx /usr/local/bin/
 
 # Install a managed Python 3.13 and create a dedicated venv at /opt/venv.
-# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists for the
-# symlinks below (and so Code Ocean's GUI recognises pip as available).
+# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists (and so
+# Code Ocean's GUI recognises pip as available).
 RUN uv python install 3.13 \
  && uv venv --seed --python 3.13 ${VIRTUAL_ENV} \
  && rm -rf /root/.cache/uv \
- # Shadow any system python/pip so scripts that say `python3` or `pip`
- # resolve to the venv regardless of how they're invoked.
- && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python \
- && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python3 \
+ # Shadow python/pip into the venv. python: wrapper, not symlink — a plain
+ # symlink leaves sys.executable=/usr/local/bin/python, so CPython's
+ # pyvenv.cfg lookup walks /usr/local and misses /opt/venv. The re-exec
+ # puts sys.executable inside /opt/venv so activation fires. pip/pip3: a
+ # symlink is fine because pip is itself a shebang script that re-execs.
+ # `rm -f` is a no-op on this image but guards against future base images
+ # that (like python:3.13-slim) ship python/python3 as symlinks to python3.13.
+ && rm -f /usr/local/bin/python /usr/local/bin/python3 \
+ && printf '#!/bin/sh\nexec /opt/venv/bin/python "$@"\n' > /usr/local/bin/python \
+ && chmod +x /usr/local/bin/python \
+ && ln -sf python /usr/local/bin/python3 \
  && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip \
  && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip3

--- a/cuda12-runtime-uv/Dockerfile
+++ b/cuda12-runtime-uv/Dockerfile
@@ -44,14 +44,21 @@ RUN apt-get update \
 COPY --from=uv /uv /uvx /usr/local/bin/
 
 # Install a managed Python 3.13 and create a dedicated venv at /opt/venv.
-# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists for the
-# symlinks below (and so Code Ocean's GUI recognises pip as available).
+# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists (and so
+# Code Ocean's GUI recognises pip as available).
 RUN uv python install 3.13 \
  && uv venv --seed --python 3.13 ${VIRTUAL_ENV} \
  && rm -rf /root/.cache/uv \
- # Shadow any system python/pip so scripts that say `python3` or `pip`
- # resolve to the venv regardless of how they're invoked.
- && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python \
- && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python3 \
+ # Shadow python/pip into the venv. python: wrapper, not symlink — a plain
+ # symlink leaves sys.executable=/usr/local/bin/python, so CPython's
+ # pyvenv.cfg lookup walks /usr/local and misses /opt/venv. The re-exec
+ # puts sys.executable inside /opt/venv so activation fires. pip/pip3: a
+ # symlink is fine because pip is itself a shebang script that re-execs.
+ # `rm -f` is a no-op on this image but guards against future base images
+ # that (like python:3.13-slim) ship python/python3 as symlinks to python3.13.
+ && rm -f /usr/local/bin/python /usr/local/bin/python3 \
+ && printf '#!/bin/sh\nexec /opt/venv/bin/python "$@"\n' > /usr/local/bin/python \
+ && chmod +x /usr/local/bin/python \
+ && ln -sf python /usr/local/bin/python3 \
  && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip \
  && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip3

--- a/python-slim-uv/Dockerfile
+++ b/python-slim-uv/Dockerfile
@@ -47,13 +47,20 @@ COPY --from=uv /uv /uvx /usr/local/bin/
 # Create a dedicated venv at /opt/venv using the base image's Python 3.13
 # (no `uv python install` — the official python:3.13-slim-trixie image
 # already provides the exact interpreter we want).
-# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists for the
-# symlinks below (and so Code Ocean's GUI recognises pip as available).
+# `--seed` installs pip into the venv so `/opt/venv/bin/pip` exists (and so
+# Code Ocean's GUI recognises pip as available).
 RUN uv venv --seed --python python3.13 ${VIRTUAL_ENV} \
  && rm -rf /root/.cache/uv \
- # Shadow system python/pip so scripts that say `python3` or `pip`
- # resolve to the venv regardless of how they're invoked.
- && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python \
- && ln -sf ${VIRTUAL_ENV}/bin/python /usr/local/bin/python3 \
+ # Shadow python/pip into the venv. python: wrapper, not symlink — a plain
+ # symlink leaves sys.executable=/usr/local/bin/python, so CPython's
+ # pyvenv.cfg lookup walks /usr/local and misses /opt/venv. The re-exec
+ # puts sys.executable inside /opt/venv so activation fires. pip/pip3: a
+ # symlink is fine because pip is itself a shebang script that re-execs.
+ # `rm -f` first: the slim-trixie base ships python/python3 as symlinks
+ # to python3.13; writing through them would clobber the real interpreter.
+ && rm -f /usr/local/bin/python /usr/local/bin/python3 \
+ && printf '#!/bin/sh\nexec /opt/venv/bin/python "$@"\n' > /usr/local/bin/python \
+ && chmod +x /usr/local/bin/python \
+ && ln -sf python /usr/local/bin/python3 \
  && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip \
  && ln -sf ${VIRTUAL_ENV}/bin/pip /usr/local/bin/pip3


### PR DESCRIPTION
Symlink-based shims at `/usr/local/bin/python{,3}` don't activate the `/opt/venv` venv — CPython uses the invocation path as `sys.executable`, so `pyvenv.cfg` lookup walks `/usr/local` (missing) instead of `/opt/venv` (present). Any script that hardcodes `/usr/local/bin/python*` silently ran the base interpreter without the venv's site-packages, and `python -m pip` via those paths invoked the wrong pip.

Replaces the `python`/`python3` symlinks in all three uv images (`python-slim-uv`, `cuda12-base-uv`, `cuda12-runtime-uv`) with a `/bin/sh` wrapper that `exec`s `/opt/venv/bin/python`. The re-exec lands `sys.executable` inside the venv so activation fires. `pip`/`pip3` stay as symlinks because pip is itself a shebang script — its own re-exec has always done the equivalent thing.

`rm -f` pre-existing symlinks before writing the wrapper: `python:3.13-slim-trixie` ships `python -> python3 -> python3.13` as a symlink chain, and `printf > /usr/local/bin/python` would follow it and overwrite the real interpreter. No-op on the cuda images but defends against future base-image bumps.

## Verified locally

All three images rebuilt from the new Dockerfiles; for each:

| Invocation | sys.prefix |
|---|---|
| `python` (via PATH) | `/opt/venv` |
| `python3` (via PATH) | `/opt/venv` |
| `/usr/local/bin/python` | `/opt/venv` |
| `/usr/local/bin/python3` | `/opt/venv` |
| `/opt/venv/bin/python` | `/opt/venv` |
| `#!/usr/local/bin/python` shebang | `/opt/venv` |
| `#!/usr/local/bin/python3` shebang | `/opt/venv` |
| `#!/usr/bin/env python3` shebang | `/opt/venv` |

`python -m pip --version` via every path reports `/opt/venv/lib/python3.13/site-packages/pip`. Subprocess chains (parent via wrapper, child via PATH) both land in the venv. Slim's upstream `/usr/local/bin/python3.13` binary is preserved intact.