### PR TITLE
ci: sets ubuntu versions to 26.04 and 24.04

### DIFF
--- a/cuda13-miniconda-jupyterlab/Dockerfile
+++ b/cuda13-miniconda-jupyterlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:13.2.1-runtime-ubuntu24.04
+FROM nvidia/cuda:13.2.1-devel-ubuntu24.04
 LABEL maintainer "David Feng <david.feng@alleninstitute.org>"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && rm -rf /var/lib/apt/lists/*
     
-ARG MINICONDA_INSTALLER=Miniconda3-py39_23.5.2-0-Linux-x86_64.sh
-ARG MINICONDA_SHA256=9829d95f639bd0053b2ed06d1204e60644617bf37dd5cc57523732e0e8d64516
+ARG MINICONDA_INSTALLER=Miniconda3-py310_23.1.0-1-Linux-x86_64.sh
+ARG MINICONDA_SHA256=32d73e1bc33fda089d7cd9ef4c1be542616bd8e437d1f77afeeaf7afdb019787
 ARG CONDA_DIR=/opt/conda
 
 RUN curl -O https://repo.anaconda.com/miniconda/${MINICONDA_INSTALLER} \
@@ -38,10 +38,3 @@ RUN conda config --system --set auto_update_conda false \
 
 RUN pip install -U --no-cache-dir jupyterlab jupyter notebook
 
-RUN pip install -U --no-cache-dir --extra-index-url https://developer.download.nvidia.com/compute/redist --upgrade nvidia-dali-cuda110
-
-RUN pip install -U --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 
-
-RUN pip install -U --no-cache-dir lightning tensorboard lightning-bolts 
-
-ENV NVIDIA_DRIVER_CAPABILITIES compute,video,utility

--- a/r2u-rstudio/Dockerfile
+++ b/r2u-rstudio/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r2u:22.04
+FROM rocker/r2u:26.04
 
 RUN wget --no-verbose https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2024.12.0-467-amd64.deb  \
         && apt-get update \

--- a/ubuntu-ffmpeg/Dockerfile
+++ b/ubuntu-ffmpeg/Dockerfile
@@ -5,7 +5,7 @@ FROM docker.io/mwader/static-ffmpeg:8.1 AS ffmpeg
 FROM docker.io/condaforge/miniforge3:26.1.1-3 AS miniforge
 
 # Stage 3: runtime
-FROM docker.io/ubuntu:24.04
+FROM docker.io/ubuntu:26.04
 
 ENV CONDA_DIR=/opt/conda
 ENV PATH=${CONDA_DIR}/bin:${PATH}


### PR DESCRIPTION
 Updates Dockerfiles to use latest available Ubuntu (26.04 or 24.04) where applicable

**Base image and dependency upgrades:**

* Updated the CUDA and Ubuntu base images in `cuda13-miniconda-jupyterlab/Dockerfile` and `lightning-jupyterlab-py39/Dockerfile` to use CUDA 13.2.1 and Ubuntu 24.04, and added a new Dockerfile for a Miniconda-based JupyterLab environment
* Updated the RStudio Dockerfile (`r2u-rstudio/Dockerfile`) to use the newer `rocker/r2u:26.04` base image, upgrading from Ubuntu 22.04 to 26.04.
* Updated the runtime base image in `ubuntu-ffmpeg/Dockerfile` from Ubuntu 24.04 to 26.04.